### PR TITLE
Add clean_heart_data function and corresponding tests

### DIFF
--- a/R/clean_heart_data.R
+++ b/R/clean_heart_data.R
@@ -1,0 +1,26 @@
+#' Clean Heart Attack Dataset
+#'
+#' Removes unnecessary columns and converts relevant columns to factors.
+#'
+#' @param df A data frame of raw heart attack data.
+#'
+#' @return A cleaned data frame with selected columns and categorical columns converted to factors.
+#' @export
+clean_heart_data <- function(df) {
+  df_clean <- df %>%
+    dplyr::select(-Patient_ID, -State_Name, -Gender) %>%
+    dplyr::mutate(
+      Diabetes = as.factor(Diabetes),
+      Hypertension = as.factor(Hypertension),
+      Obesity = as.factor(Obesity),
+      Smoking = as.factor(Smoking),
+      Alcohol_Consumption = as.factor(Alcohol_Consumption),
+      Physical_Activity = as.factor(Physical_Activity),
+      Air_Pollution_Exposure = as.factor(Air_Pollution_Exposure),
+      Family_History = as.factor(Family_History),
+      Heart_Attack_History = as.factor(Heart_Attack_History),
+      Health_Insurance = as.factor(Health_Insurance),
+      Heart_Attack_Risk = as.factor(Heart_Attack_Risk)
+    )
+  return(df_clean)
+}

--- a/tests/testthat/test-clean_heart_data.R
+++ b/tests/testthat/test-clean_heart_data.R
@@ -1,0 +1,31 @@
+library(testthat)
+source("../../R/clean_heart_data.R")
+
+# Expected use case: function should clean and convert columns correctly
+test_that("clean_heart_data returns cleaned data frame", {
+  df_cleaned <- clean_heart_data(test_df)
+
+  # 1. Should return a data.frame or tibble
+  expect_s3_class(df_cleaned, "data.frame")
+
+  # 2. Should not contain columns that are supposed to be removed
+  expect_false(any(c("Patient_ID", "State_Name", "Gender") %in% colnames(df_cleaned)))
+
+  # 3. All columns should be factors
+  expect_true(all(sapply(df_cleaned, is.factor)))
+})
+
+# Edge case: input is an empty tibble
+test_that("clean_heart_data returns empty tibble if given empty tibble", {
+  empty_input <- test_df[0, ]
+  df_cleaned <- clean_heart_data(empty_input)
+
+  expect_equal(nrow(df_cleaned), 0)
+  expect_equal(ncol(df_cleaned), ncol(test_df) - 3)  # Should retain all columns except 3 removed ones
+})
+
+# Error case: input is not a data frame
+test_that("clean_heart_data throws error for non-dataframe input", {
+  expect_error(clean_heart_data("not a dataframe"))
+  expect_error(clean_heart_data(list(a = 1, b = 2)))
+})


### PR DESCRIPTION
Cleans the heart attack dataset by removing unnecessary columns (Patient_ID, State_Name, Gender)

Converts categorical columns to factors for downstream analysis

It also includes a corresponding test file in tests/testthat/ that covers:

1. Expected use 2.Edge case 3. Error case 